### PR TITLE
send2trash: updated to 1.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Send2Trash" %}
-{% set version = "1.5.0" %}
-{% set sha256 = "60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2" %}
+{% set version = "1.8.0" %}
+{% set sha256 = "d2c24762fd3759860a0aff155e45871447ea58d2be6bdd39b5c8f966a0c99c2d" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,13 @@ test:
     - python -c "from send2trash import *; send2trash('test.txt')"
 
 about:
-  home: https://github.com/hsoft/send2trash
+  home: https://github.com/arsenetar/send2trash
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Python library to natively send files to Trash (or Recycle bin) on all platforms.
+  dev_url: https://github.com/arsenetar/send2trash
+  doc_url: https://github.com/arsenetar/send2trash/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,10 @@ requirements:
 test:
   imports:
     - send2trash
+  requires:
+    - pip
   commands:
+    - pip check
     - echo test > test.txt
     - python -c "from send2trash import *; send2trash('test.txt')"
 


### PR DESCRIPTION
* [x] upstream valid https://github.com/arsenetar/send2trash
* [x] compare pinned versions from upstream github setup
  * no pins in recipe
  * setup.cfg:
```
Programming Language :: Python :: 2.7
Programming Language :: Python :: 3
Programming Language :: Python :: 3.5
Programming Language :: Python :: 3.6
Programming Language :: Python :: 3.7
Programming Language :: Python :: 3.8
Programming Language :: Python :: 3.9
Programming Language :: Python :: 3.10

python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*

envlist = py{27,34,35,36,37,38,39,310}
```
* [x] go through [changelog](https://github.com/arsenetar/send2trash/blob/master/CHANGES.rst)
  * 20 or so PRs between 1.5.0 and 1.8.0
  * many are fixes but not all - see below for tests run 
* [x] dev_url, doc_url valid
* [x] pip/setuptools/wheel/pip check included
* [x] look for any open issues for new versions
  * 16 open issues on upstream, no issues on either feedstock
* [x] run additional tests
```
git-cola-feedstock/recipe/meta.yaml:    - send2trash
jupyter_server-feedstock/recipe/meta.yaml:    - send2trash
notebook-feedstock/recipe/meta.yaml:    - send2trash >=1.5.0
send2trash-feedstock/recipe/meta.yaml:    - send2trash
```
Successfully built git-cola with locally built send2trash 1.8.0